### PR TITLE
Fix MkDocs v7 feature regressions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@
 # LIMITATIONS UNDER THE LICENSE.
 
 mkdocs-enumerate-headings-plugin
-mkdocs-material
+mkdocs-material<6.2
 mkdocs-pdf-export-plugin
 pandocfilters


### PR DESCRIPTION
Pin all requirements files to mkdocs-material<6.2